### PR TITLE
chore: bump to setup-xc@v1

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -17,7 +17,7 @@ runs:
   steps:
     - name: Use XC
       id: use_xc
-      uses: joerdav/setup-xc@v0.0.2
+      uses: joerdav/setup-xc@v1
       with:
         version: ${{ inputs.version }}
     - name: Run ${{ inputs.task }}


### PR DESCRIPTION
Getting a warning because of the outdated node dependency in `setup-xc`, hence the bump to v1.

<img width="939" alt="Screenshot 2024-10-30 at 17 08 29" src="https://github.com/user-attachments/assets/2575856b-eda7-4102-8905-51ffb9aa00ff">
